### PR TITLE
Fix padding top in JS sprinkles feature box on smaller devices

### DIFF
--- a/app/views/application/home/_features.html.erb
+++ b/app/views/application/home/_features.html.erb
@@ -109,7 +109,7 @@
                     <div class="absolute inset-0 translate-z-0 bg-yellow-900 rounded-full blur-[80px]"></div>
                   </div>
                   <!-- Text -->
-                  <div class="md:max-w-[480px] shrink-0 order-1 md:order-none p-6 pt-0 md:p-8">
+                  <div class="md:max-w-[480px] shrink-0 order-1 md:order-none p-6 md:p-8">
                     <div>
                       <h3 class="inline-flex text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-200/60 via-slate-200 to-slate-200/60 pb-1">
                         JavaScript Sprinkles


### PR DESCRIPTION
(Sorry missed this one before)