### PR TITLE
Add RSS and archive links to the newsletter page

### DIFF
--- a/app/content/pages/newsletter.html.erb
+++ b/app/content/pages/newsletter.html.erb
@@ -22,4 +22,8 @@ title: Hotwire Weekly
 
     <input type="submit" value="Subscribe" class="mt-6 rounded-md bg-indigo-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500">
   </form>
+  <div class="mt-6">
+    <p class="text-base text-slate-200">You can also browse the <a href="https://buttondown.email/hotwireweekly/archive/" class="underline underline-offset-4">archive</a> of this newsletter.</p>
+    <p class="mt-3 text-base text-slate-200">If you'd prefer, you can also <a href="https://buttondown.email/hotwireweekly/rss" class="underline underline-offset-4">subscribe via RSS</a>.</p>
+  </div>
 <% end %>


### PR DESCRIPTION
# Notable Changes

* This PR aims to add RSS and archive links to the newsletter page.

## Screenshots (Optional)

| Newsletter Page With RSS and Archive Links |
|----------------------------------------------|
| <img width="1161" alt="rss-and-archive-link Screenshot" src="https://github.com/marcoroth/hotwire.io/assets/25585114/b433734a-bc0d-45a7-a047-f32680b23a4c"> |

## Todo

* N/A
