### PR TITLE
Tweaks the Laravel Integration & Editors Pages

### DIFF
--- a/app/content/pages/frameworks/laravel.html.erb
+++ b/app/content/pages/frameworks/laravel.html.erb
@@ -21,5 +21,5 @@ breadcrumb: Laravel
   <h3 class="mt-12 text-2xl font-bold">Guides</h3>
   
   <%= link_to "LaravelNews Post Introducing Turbo Laravel", "https://laravel-news.com/use-basecamps-hotwire-in-laravel", target: :_blank %><br>
-  <%= link_to "Free Introduction Screencasts by Maintainer of Turbo Laravel (2021)", "https://www.tonysm.com/courses/hotwire-laravel/", target: :_blank %><br>
+  <%= link_to "Introduction to Hotwire & Turbo Laravel (screencasts - 2021)", "https://www.tonysm.com/courses/hotwire-laravel/", target: :_blank %><br>
 <% end %>

--- a/app/content/pages/frameworks/laravel.html.erb
+++ b/app/content/pages/frameworks/laravel.html.erb
@@ -19,7 +19,7 @@ breadcrumb: Laravel
   <%= link_to "Rich Text Laravel (Trix)", "https://github.com/tonysm/rich-text-laravel", target: :_blank %><br>
 
   <h3 class="mt-12 text-2xl font-bold">Guides</h3>
-  
+
   <%= link_to "LaravelNews Post Introducing Turbo Laravel", "https://laravel-news.com/use-basecamps-hotwire-in-laravel", target: :_blank %><br>
   <%= link_to "Introduction to Hotwire & Turbo Laravel (screencasts - 2021)", "https://www.tonysm.com/courses/hotwire-laravel/", target: :_blank %><br>
 <% end %>

--- a/app/content/pages/frameworks/laravel.html.erb
+++ b/app/content/pages/frameworks/laravel.html.erb
@@ -10,11 +10,16 @@ breadcrumb: Laravel
 <%= render Page::ContainerComponent.new(page: current_page) do |page| %>
   <% page.with_title(title: current_page.data.fetch("title")) %>
 
-  <%= link_to "https://github.com/hotwired-laravel", "https://github.com/hotwired-laravel", target: :_blank %><br>
-  <%= link_to "https://turbo-laravel.com", "https://turbo-laravel.com", target: :_blank %><br>
-  <%= link_to "https://laravel-news.com/use-basecamps-hotwire-in-laravel", "https://laravel-news.com/use-basecamps-hotwire-in-laravel", target: :_blank %><br>
-  <%= link_to "https://symfonycasts.com/screencast/stimulus", "https://symfonycasts.com/screencast/stimulus", target: :_blank %><br>
-  <%= link_to "https://github.com/tonysm/rich-text-laravel", "https://github.com/tonysm/rich-text-laravel", target: :_blank %><br>
-  <%= link_to "https://github.com/tonysm/importmap-laravel", "https://github.com/tonysm/importmap-laravel", target: :_blank %><br>
-  <%= link_to "https://github.com/tonysm/globalid-laravel", "https://github.com/tonysm/globalid-laravel", target: :_blank %><br>
+  <h3 class="mt-12 text-2xl font-bold">Setup</h3>
+
+  <%= link_to "Turbo Laravel Website & Documentation", "https://turbo-laravel.com", target: :_blank %><br>
+  <%= link_to "Stimulus Laravel", "https://github.com/hotwired-laravel/stimulus-laravel", target: :_blank %><br>
+  <%= link_to "Importmap Laravel", "https://github.com/tonysm/importmap-laravel", target: :_blank %><br>
+  <%= link_to "TailwindCSS Laravel", "https://github.com/tonysm/tailwindcss-laravel", target: :_blank %><br>
+  <%= link_to "Rich Text Laravel (Trix)", "https://github.com/tonysm/rich-text-laravel", target: :_blank %><br>
+
+  <h3 class="mt-12 text-2xl font-bold">Guides</h3>
+  
+  <%= link_to "LaravelNews Post Introducing Turbo Laravel", "https://laravel-news.com/use-basecamps-hotwire-in-laravel", target: :_blank %><br>
+  <%= link_to "Free Introduction Screencasts by Maintainer of Turbo Laravel (2021)", "https://www.tonysm.com/courses/hotwire-laravel/", target: :_blank %><br>
 <% end %>

--- a/app/content/pages/use-cases/editors.html.erb
+++ b/app/content/pages/use-cases/editors.html.erb
@@ -5,26 +5,24 @@ title: WYSIWYG Editors
 <%= render Page::ContainerComponent.new(page: current_page) do |page| %>
   <% page.with_title(title: current_page.data.fetch("title")) %>
 
-  Rich Text Editors: <br>
-  <%= link_to "https://trix-editor.org", "https://trix-editor.org", target: :_blank %><br>
-  <%= link_to "https://rhino-editor.vercel.app", "https://rhino-editor.vercel.app", target: :_blank %><br>
-  <%= link_to "https://richer-text.vercel.app", "https://richer-text.vercel.app", target: :_blank %><br>
+  <h3 class="mt-12 text-2xl font-bold">Rich Text Editors</h3>
 
-  <br>
+  <%= link_to "Trix", "https://trix-editor.org", target: :_blank %><br>
+  <%= link_to "Rhino", "https://rhino-editor.vercel.app", target: :_blank %><br>
+  <%= link_to "RicherText", "https://richer-text.vercel.app", target: :_blank %><br>
+   
+  <h3 class="mt-12 text-2xl font-bold">Libraries for building Rich Text Editors</h3>
 
-  Libraries for building Rich Text Editors: <br>
-  <%= link_to "https://tiptap.dev", "https://tiptap.dev", target: :_blank %><br>
-  <%= link_to "https://prosemirror.net", "https://prosemirror.net", target: :_blank %><br>
-  <%= link_to "https://lexical.dev", "https://lexical.dev", target: :_blank %><br>
+  <%= link_to "Tiptap", "https://tiptap.dev", target: :_blank %><br>
+  <%= link_to "ProseMirror", "https://prosemirror.net", target: :_blank %><br>
+  <%= link_to "lexical", "https://lexical.dev", target: :_blank %><br>
+  
+  <h3 class="mt-12 text-2xl font-bold">Rails</h3>
+  
+  <%= link_to "Action Text Guides", "https://edgeguides.rubyonrails.org/action_text_overview.html", target: :_blank %><br>
 
-  <br>
-
-  Rails: <br>
-  <%= link_to "https://edgeguides.rubyonrails.org/action_text_overview.html", "https://edgeguides.rubyonrails.org/action_text_overview.html", target: :_blank %><br>
-
-  <br>
-
-  Laravel: <br>
-  <%= link_to "tonysm/rich-text-laravel", "https://github.com/tonysm/rich-text-laravel", target: :_blank %><br>
-  <%= link_to "Rich Text Laravel - Introduction", "https://www.youtube.com/watch?v=VX4-4iWnGIo", target: :_blank %><br>
+  <h3 class="mt-12 text-2xl font-bold">Laravel</h3>
+  
+  <%= link_to "Rich Text Laravel", "https://github.com/tonysm/rich-text-laravel", target: :_blank %><br>
+  <%= link_to "Introductiont to Rich Text Laravel (screencast)", "https://www.youtube.com/watch?v=VX4-4iWnGIo", target: :_blank %><br>
 <% end %>

--- a/app/content/pages/use-cases/editors.html.erb
+++ b/app/content/pages/use-cases/editors.html.erb
@@ -10,19 +10,19 @@ title: WYSIWYG Editors
   <%= link_to "Trix", "https://trix-editor.org", target: :_blank %><br>
   <%= link_to "Rhino", "https://rhino-editor.vercel.app", target: :_blank %><br>
   <%= link_to "RicherText", "https://richer-text.vercel.app", target: :_blank %><br>
-   
+
   <h3 class="mt-12 text-2xl font-bold">Libraries for building Rich Text Editors</h3>
 
   <%= link_to "Tiptap", "https://tiptap.dev", target: :_blank %><br>
   <%= link_to "ProseMirror", "https://prosemirror.net", target: :_blank %><br>
   <%= link_to "lexical", "https://lexical.dev", target: :_blank %><br>
-  
+
   <h3 class="mt-12 text-2xl font-bold">Rails</h3>
-  
+
   <%= link_to "Action Text Guides", "https://edgeguides.rubyonrails.org/action_text_overview.html", target: :_blank %><br>
 
   <h3 class="mt-12 text-2xl font-bold">Laravel</h3>
-  
+
   <%= link_to "Rich Text Laravel", "https://github.com/tonysm/rich-text-laravel", target: :_blank %><br>
   <%= link_to "Introductiont to Rich Text Laravel (screencast)", "https://www.youtube.com/watch?v=VX4-4iWnGIo", target: :_blank %><br>
 <% end %>


### PR DESCRIPTION
### Changed

- Tweaks how the Laravel Integration page looks (just tweaked the styles a bit and removed `globalid-laravel`)
- Tweaks how the editors page looks (just link text and a bit of styles)

---

<details>
<summary>Screenshots</summary>

![Screenshot from 2023-10-31 23-40-13](https://github.com/marcoroth/hotwire.io/assets/1178621/f4d76afb-d80c-4840-9e27-8acba1ba9223)
![Screenshot from 2023-10-31 23-40-21](https://github.com/marcoroth/hotwire.io/assets/1178621/9d21d452-fdfa-49e9-8d51-27a1d6790492)


</details>