### PR TITLE
Add Wagtail as a framework supporting Stimulus

### DIFF
--- a/app/content/pages/frameworks/wagtail.html.erb
+++ b/app/content/pages/frameworks/wagtail.html.erb
@@ -1,0 +1,15 @@
+---
+title: Using Stimulus within Wagtail
+framework: Wagtail
+language: Python
+description: Wagtail is an open source CMS built on Django, with a strong community and commercial support. Focused on user experience with precise control for designers and developers.
+icon_class: devicon-python-plain text-5xl
+breadcrumb: Wagtail
+---
+
+<%= render Page::ContainerComponent.new(page: current_page) do |page| %>
+  <% page.with_title(title: current_page.data.fetch("title")) %>
+
+  <%= link_to "Documentation", "https://docs.wagtail.org/en/stable/extending/extending_client_side.html#extending-with-stimulus", target: :_blank %><br>
+  <%= link_to "5.2 Release Notes", "https://docs.wagtail.org/en/stable/releases/5.2.html#support-extending-wagtail-client-side-with-stimulus", target: :_blank %><br>
+<% end %>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -52,6 +52,7 @@
           <li><a class="text-slate-400 hover:text-slate-200 transition duration-150 ease-in-out" href="/frameworks/laravel">Laravel</a></li>
           <li><a class="text-slate-400 hover:text-slate-200 transition duration-150 ease-in-out" href="/frameworks/symfony">Symfony</a></li>
           <li><a class="text-slate-400 hover:text-slate-200 transition duration-150 ease-in-out" href="/frameworks/django">Django</a></li>
+          <li><a class="text-slate-400 hover:text-slate-200 transition duration-150 ease-in-out" href="/frameworks/wagtail">Wagtail</a></li>
           <li><a class="text-slate-400 hover:text-slate-200 transition duration-150 ease-in-out" href="/frameworks/hanami">Hanami</a></li>
           <li><a class="text-slate-400 hover:text-slate-200 transition duration-150 ease-in-out" href="/frameworks/roda">Roda</a></li>
           <li><a class="text-slate-400 hover:text-slate-200 transition duration-150 ease-in-out" href="/frameworks/bridgetown">Bridgetown</a></li>

--- a/app/views/application/home/_integrations.html.erb
+++ b/app/views/application/home/_integrations.html.erb
@@ -35,6 +35,10 @@
           <i class="devicon-django-plain text-5xl"></i>
         </a>
 
+        <a href="/frameworks/wagtail" class="rounded-xl relative flex justify-center items-center bg-gray--900 aspect-square p-2">
+          <i class="devicon-python-plain text-5xl"></i>
+        </a>
+
         <a href="/frameworks/bridgetown" class="rounded-xl relative flex justify-center items-center bg-gray--900 aspect-square p-2">
           <img src="<%= image_path("frameworks/bridgetown.png") %>" alt="Bridgetown Logo" class="max-w-[60px]">
         </a>


### PR DESCRIPTION
With the release of Wagtail 5.2 we now have official support of customising the admin interface with Stimulus, including documentation for how to do this without any build tools (a big win for our community). Wagtail is also extensively using Stimulus for the admin UI but the main focus of this is developer facing tooling.

Wagtail does not have a [devicon yet](https://github.com/devicons/devicon/issues/1559) so I have just used Python instead.

Closes #57

Happy to adjust or add more content to the page if needed.