### PR TITLE
feat: Add Stimulus LSP Installation Guide for Neovim

### DIFF
--- a/app/content/pages/ecosystem/tooling/stimulus-lsp.html.erb
+++ b/app/content/pages/ecosystem/tooling/stimulus-lsp.html.erb
@@ -31,7 +31,7 @@ image: stimulus-lsp.png
       <a href="/ecosystem/tooling/stimulus-lsp/install/neovim" class="flex items-center gap-2 hover:text-gray-400">
         <i class="devicon-vim-plain text-3xl"></i>
 
-        NeoVim
+        Neovim
       </a>
 
       <a href="/ecosystem/tooling/stimulus-lsp/install" class="flex items-center gap-2 hover:text-gray-400">

--- a/app/content/pages/ecosystem/tooling/stimulus-lsp/install/neovim.html.erb
+++ b/app/content/pages/ecosystem/tooling/stimulus-lsp/install/neovim.html.erb
@@ -8,5 +8,5 @@ breadcrumb: NeoVim
 <%= render Page::ContainerComponent.new(page: current_page) do |page| %>
   <% page.with_title(title: current_page.data.fetch("subtitle")) %>
 
-  <%= render Page::ContributeComponent.new(file: current_page.asset.path.path) %>
+  <%= link_to "neovim/nvim-lspconfig", "https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#stimulus_ls", target: :_blank %><br>
 <% end %>

--- a/app/content/pages/ecosystem/tooling/stimulus-lsp/install/neovim.html.erb
+++ b/app/content/pages/ecosystem/tooling/stimulus-lsp/install/neovim.html.erb
@@ -1,8 +1,8 @@
 ---
-title: NeoVim
-subtitle: Install Stimulus LSP in NeoVim
+title: Neovim
+subtitle: Install Stimulus LSP in Neovim
 editor: neovim
-breadcrumb: NeoVim
+breadcrumb: Neovim
 ---
 
 <%= render Page::ContainerComponent.new(page: current_page) do |page| %>


### PR DESCRIPTION
- Add Stimulus LSP Installation Guide for Neovim
- Updated to use the term `Neovim` instead of `NeoVim`
