### PR TITLE
add stimulus-store to state-managment libs

### DIFF
--- a/app/content/pages/ecosystem/state-management/stimulus-store.html.erb
+++ b/app/content/pages/ecosystem/state-management/stimulus-store.html.erb
@@ -1,0 +1,10 @@
+---
+title: stimulus-store
+image: https://raw.githubusercontent.com/omarluq/stimulus-store/main/docs/images/stimulus_store_logo_bg_black_high_dif.png
+---
+
+<%= render Page::ContainerComponent.new(page: current_page) do |page| %>
+  <% page.with_title(title: current_page.data.fetch("title")) %>
+
+  <%= link_to "omarluq/stimulus-store", "https://github.com/omarluq/stimulus-store", target: :_blank %><br>
+<% end %>


### PR DESCRIPTION
Hello, I would like to add `stimulus-store` a package I've recently published for state management in stimulus apps to the ecosystem cards, Thank you for your consideration.