### PR TITLE
Rename Footer Link 'Editor Tooling' to 'Tooling'

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -31,7 +31,7 @@
           <li><a class="text-slate-300 hover:text-slate-200 transition duration-150 ease-in-out" href="/ecosystem/extensions">Extending Core</a></li>
           <li><a class="text-slate-300 hover:text-slate-200 transition duration-150 ease-in-out" href="/ecosystem/new-concepts">New Concepts</a></li>
           <li><a class="text-slate-300 hover:text-slate-200 transition duration-150 ease-in-out" href="/ecosystem/helpers">Helper Libraries</a></li>
-          <li><a class="text-slate-300 hover:text-slate-200 transition duration-150 ease-in-out" href="/ecosystem/tooling">Editor Tooling</a></li>
+          <li><a class="text-slate-300 hover:text-slate-200 transition duration-150 ease-in-out" href="/ecosystem/tooling">Tooling</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Hi,

This PR would change the footer link text from 'Editor Tooling' to 'Tooling' to align with the effective page title.    
I noticed it, because it wasn't clear to me, that the page contains more than editor related tools.