### PR TITLE
Add RailsbootUI to UI Frameworks

### DIFF
--- a/app/content/pages/ecosystem/ui-frameworks/railsbootui.html.erb
+++ b/app/content/pages/ecosystem/ui-frameworks/railsbootui.html.erb
@@ -1,0 +1,14 @@
+---
+title: RailsbootUI
+---
+
+<%= render Page::ContainerComponent.new(page: current_page) do |page| %>
+  <% page.with_title(title: current_page.data.fetch("title")) %>
+
+  RailsbootUI is a view component collection for Bootstrap.
+  <br><br>
+
+  <%= link_to "Official Site", "https://railsbootui.com", target: :_blank %><br>
+  <%= link_to "Components", "https://railsbootui.com/components", target: :_blank %><br>
+  <%= link_to "Documentation", "https://railsbootui.com/docs/introduction", target: :_blank %>
+<% end %>


### PR DESCRIPTION
Added [RailsbootUI](https://railsbootui.com/) as another UI component framework which uses Hotwire and/or Stimulus for many of the components.