### PR TITLE
Fixes Swiper carousel navigation

### DIFF
--- a/app/javascript/config/swiper.js
+++ b/app/javascript/config/swiper.js
@@ -1,8 +1,12 @@
 import Swiper from 'swiper'
+import { Navigation } from 'swiper/modules';
+
+Swiper.use([Navigation]);
 
 document.addEventListener("turbo:load", () => {
   document.querySelectorAll('.carousel').forEach(element => {
     new Swiper(element, {
+      modules: [Navigation],
       breakpoints: {
         320: {
           slidesPerView: 1


### PR DESCRIPTION
## Problem:
The navigation buttons (previous/next) of the carousel were not working because the Swiper Navigation module was missing its import and registration.

## Changes made:
1- I added the Navigation module:
- Swiper (starting from version 6+) uses a modular structure, where extra functionalities (like navigation) need to be imported and registered separately.

- Previously, only the Swiper core was loaded, so the navigation buttons were ignored.

2- Initialization adjustment:

- I registered the module with Swiper.use([Navigation]) to enable the functionality globally.

- I ensured that the navigation configuration (in the Swiper options object) correctly recognizes the button selectors.

## Impact:
The navigation buttons now work as expected.

## Note:
If we need other Swiper features in the future (such as pagination or scrollbar), we just need to import and register their modules following the same pattern.