### PR TITLE
fix: remove broken links from education

### DIFF
--- a/app/content/data/courses.yml
+++ b/app/content/data/courses.yml
@@ -22,10 +22,6 @@
   url: https://symfonycasts.com/screencast/turbo
   price: paid
 
-- name: Hotwire Cookbook
-  url: https://www.hotwirecookbook.com
-  price: paid
-
 - name: "SymfonyCasts - 30 Days with LAST Stack"
   url: https://symfonycasts.com/screencast/last-stack
   price: paid

--- a/app/content/data/tutorials.yml
+++ b/app/content/data/tutorials.yml
@@ -1,9 +1,6 @@
 - name: Hotrails.dev
   url: https://www.hotrails.dev
 
-- name: Turbo Laravel Bootcamp
-  url: https://bootcamp.turbo-laravel.com
-
 - name: Hotwire PowerPlay
   url: https://github.com/hotwire-django/PowerPlay
 


### PR DESCRIPTION
Cleaning up some links on education page.